### PR TITLE
Feature/load amp boilerplate only on non amp

### DIFF
--- a/classes/class-amp-admanager.php
+++ b/classes/class-amp-admanager.php
@@ -232,7 +232,13 @@ class AMP_AdManager {
 			return;
 		}
 
-		// Load template for amp boilerplate style sheet.	
-		load_template( AMP_ADMANAGER_ROOT . '/template-parts/amp-boilerplate-css.php' );
+		$should_load_resources = self::$amp_settings['load-amp-resources'];
+
+		if ( ! empty( $should_load_resources ) && '1' === $should_load_resources ) {
+
+			// Load amp-boilerplate css template only if `load amp resources` is enabled.
+			load_template( AMP_ADMANAGER_ROOT . '/template-parts/amp-boilerplate-css.php' );
+
+		}
 	}
 }


### PR DESCRIPTION
AMP pages give validation error because amp-admanager plugin is adding boilterplate CSS and AMP plugin is also add boilerplate css.

So this PR loads boilerplate css only if the current page is not AMP page and if `load resources` setting is enabled.

![Screenshot 2019-04-09 at 7 35 11 PM](https://user-images.githubusercontent.com/1139853/55806803-a05aa980-5afe-11e9-93ae-06e6d98a6bec.png)

