### PR TITLE
Add amp resources at the top of wp_head

### DIFF
--- a/template-parts/amp-resources.php
+++ b/template-parts/amp-resources.php
@@ -1,18 +1,16 @@
 <?php
 /**
- * Load amp boilerplate style sheet code.
+ * Load AMP Resources.
+ * This will load amp-boilerplate CSS and amp-runtime script. Ideally at the top of the wp_head.
  *
  * @author Vishal Dodiya <vishal.dodiya@rtcamp.com>
+ *
+ * @since 0.2
  *
  * @package AMP_AdManager
  */
 
-if ( function_exists( 'amp_get_boilerplate_code' ) ) {
-	echo amp_get_boilerplate_code(); // phpcs:ignore
-	return;
-}
 ?>
-
 <style amp-boilerplate>
 	body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}
 </style>
@@ -21,3 +19,5 @@ if ( function_exists( 'amp_get_boilerplate_code' ) ) {
 		body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}
 	</style>
 </noscript>
+<link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
+<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>


### PR DESCRIPTION
Loads `AMP boilerplate CSS` and `amp-runtime` v0.js script at the top of `wp_head`.
This is to avoid any delay for amp resources caused by other stylesheets and scripts.