### PR TITLE
Fix loading of sra tag on amp pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ AMP_AdManager\AMP_AdManager::get_ads( $attr, true );
 
 ### v0.9 (27-09-2019)
 * Add missing single page targeting variables.
+* Fix SRA tag loading on both AMP and Non-AMP pages.
 
 ### v0.8 (20-09-2019)
 * Add ad refresh support.

--- a/classes/class-amp-admanager.php
+++ b/classes/class-amp-admanager.php
@@ -404,6 +404,11 @@ class AMP_AdManager {
 	 */
 	public function load_amp_resources() {
 
+		// Add DFP single request mode for ad rendering ref - https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/sra.md for more info.
+		?>
+		<meta name="amp-ad-doubleclick-sra" />
+		<?php
+
 		// Check if current page is amp page.
 		if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
 			return;

--- a/template-parts/amp-resources.php
+++ b/template-parts/amp-resources.php
@@ -21,4 +21,3 @@
 </noscript>
 <link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
 <script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>
-<meta name="amp-ad-doubleclick-sra"/>


### PR DESCRIPTION
Loads SRA meta tag on both AMP and NON-AMP pages regardless of AMP resources loading.