### PR TITLE
Fix issue with custom targeting attributes in get_ads

### DIFF
--- a/classes/class-amp-admanager.php
+++ b/classes/class-amp-admanager.php
@@ -120,12 +120,34 @@ class AMP_AdManager {
 		$final_ad_data = [];
 		$final_ad_data['targeting'] = $dfp_ad_data;
 
+		if ( ! empty( $attr['custom-targeting'] ) ) {
+
+			// Separate out all key values in array.
+			$custom_targeting = explode( ',', trim( $attr['custom-targeting'] ) );
+
+			if ( ! empty( $custom_targeting ) ) {
+
+				foreach ( $custom_targeting as $value ) {
+
+					// Separate out individual targeting key values as $key => $value pair.
+					$new_key_value = explode( ':', trim( $value ) );
+
+					if ( ! empty( $new_key_value ) ) {
+						$attr['targeting'][ trim( $new_key_value[0] ) ] = trim( $new_key_value[1] );
+					}
+				}
+			}
+		}
+
 		if ( ! empty( $attr['targeting'] ) ) {
 			$final_ad_data['targeting'] = array_unique( array_merge( $dfp_ad_data, $attr['targeting'] ) );
 		}
 
 		/**
-		 * amp_dfp_targeting_data filter to customize targeting variable.
+		 * Filters the targeting attribute for the AMP AD.
+		 *
+		 * @param array $targetting An array of targetting attribute data.
+		 * @param array $attr       An array of get_ads() attributes.
 		 */
 		$final_ad_data['targeting'] = apply_filters( 'amp_dfp_targeting_data', $final_ad_data['targeting'], $attr );
 

--- a/classes/class-amp-admanager.php
+++ b/classes/class-amp-admanager.php
@@ -146,7 +146,7 @@ class AMP_AdManager {
 		/**
 		 * Filters the targeting attribute for the AMP AD.
 		 *
-		 * @param array $targetting An array of targetting attribute data.
+		 * @param array $targeting  An array of targeting attribute data.
 		 * @param array $attr       An array of get_ads() attributes.
 		 */
 		$final_ad_data['targeting'] = apply_filters( 'amp_dfp_targeting_data', $final_ad_data['targeting'], $attr );

--- a/tests/classes/test-class-amp-admanager.php
+++ b/tests/classes/test-class-amp-admanager.php
@@ -583,7 +583,7 @@ class Test_AMP_AdManager extends \WP_UnitTestCase {
 		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0.js" async></script>', $output ); // phpcs:ignore
 
 		Utility::mock_amp( true );
-		$output                      = Utility::buffer_and_return( [ $this->_instance, 'load_amp_resources' ] );
+		$output = Utility::buffer_and_return( [ $this->_instance, 'load_amp_resources' ] );
 		$this->assertEquals( $expected, $output );
 		Utility::mock_amp( false );
 

--- a/tests/classes/test-class-amp-admanager.php
+++ b/tests/classes/test-class-amp-admanager.php
@@ -338,7 +338,7 @@ class Test_AMP_AdManager extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $output );
 		$this->assertEquals( $expected_output, $output );
 
-		// Custom targetting.
+		// Custom targeting.
 		$expected_output = '<amp-ad width="970" height="250" media="(min-width: 800px)" type="doubleclick" data-slot="/123456789/AMP_ADTest" json=\'{&quot;targeting&quot;:{&quot;contentType&quot;:&quot;&quot;,&quot;siteDomain&quot;:&quot;test.com&quot;,&quot;adId&quot;:&quot;AMP_ADTest&quot;,&quot;test&quot;:&quot;test2&quot;}}\' data-multi-size="970x250" data-multi-size-validation="false" layout="responsive" data-loading-strategy="prefer-viewability-over-views" data-enable-refresh=></amp-ad>';
 		$ad_attr         = [
 			'ad-unit'          => 'AMP_ADTest',

--- a/tests/helpers/class-utility.php
+++ b/tests/helpers/class-utility.php
@@ -148,4 +148,20 @@ class Utility {
 		// phpcs:enable
 	}
 
+	/**
+	 * Utility method to fool is_amp_endpoint() into believing current URL is an AMP URL
+	 *
+	 * @return void
+	 */
+	public static function mock_amp( $amp_query_var = true ) {
+
+		if ( ! defined( 'AMP_QUERY_VAR' ) ) {
+			// AMP plugin should already have this variable define, fallback condition never reached by unit test
+			define( 'AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp' ) ); // @codeCoverageIgnore
+		}
+
+		set_query_var( AMP_QUERY_VAR, $amp_query_var );
+
+	}
+
 }


### PR DESCRIPTION
- Fix issue with custom-targeting attribute not taking effect in the amp ad.
- Fixed test cases and covered full code coverage.